### PR TITLE
oldm-shape, prefix order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ package-lock.json
 packages/oldm/.tap/*
 packages/oldm-core/.tap/*
 packages/oldm-n3/.tap/*
+packages/oldm-turtle/.tap/*
+packages/oldm-shape/.tap/*

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ OLDM is now structured as a small npm-workspaces monorepo. The split keeps the c
 | `@muze-nl/oldm-core` | Core object/graph mapping, helpers, and classes. Explicit ESM exports only. No N3 dependency and no global side effects. |
 | `@muze-nl/oldm-n3` | N3 parser/writer adapter for OLDM. Depends on `n3` and `@muze-nl/oldm-core`. |
 | `@muze-nl/oldm` | Beginner-friendly package. Exports one default `oldm` object, provides default N3 parser/writer wiring, browser bundles, and sets `globalThis.oldm`. |
+| `@muze-labs/oldm-shape` | Experimental assert-style object shapes for validating JavaScript objects and mapping them to and from OLDM objects. |
 
 ## Installation
 
@@ -38,6 +39,12 @@ const context = oldm({
   parser: n3Parser,
   writer: n3Writer
 })
+```
+
+For experimental object shapes:
+
+```shell
+npm install @muze-labs/oldm-shape @muze-nl/oldm-core @muze-nl/assert
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ const context = oldm({
 ```
 
 
+## Prefix preference
+
+OLDM shortens predicate and type IRIs with the prefixes configured on the context. Prefix declarations found in Turtle input are parser conveniences; they do not decide the JavaScript property names exposed by OLDM.
+
+When multiple prefixes point at the same namespace, client-provided prefixes are preferred over OLDM defaults, and defaults are preferred over prefixes found in a parsed source document. For example, both `pim:` and `space:` are common aliases for `http://www.w3.org/ns/pim/space#`. Since OLDM prefers `space` for that namespace, profile data using either `pim:storage` or `space:storage` is exposed as `space$storage` in JavaScript.
+
+```javascript
+const context = oldm({
+  parser: n3Parser,
+  prefixes: {
+    space: 'http://www.w3.org/ns/pim/space#'
+  }
+})
+
+const profile = context.parse(turtle, profileUrl, 'text/turtle')
+const me = profile.subjects[`${profileUrl}#me`]
+
+console.log(me.space$storage.id)
+```
+
+
 ## Multiple graphs in one context
 
 A context keeps a registry of every parsed graph. Each `context.parse()` call still returns a `Graph` for the parsed resource, while the context exposes a combined view over all graphs loaded into that context.
@@ -57,8 +78,6 @@ context.graphs                        // [profile, settings]
 context.graph(profileUrl)             // profile
 context.data                          // combined subject list
 context.subjects                      // combined subject map by full URI
-profile.context.data                  // same combined view, starting from a graph
-profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // [profile, settings] when both graphs contain data for that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
@@ -66,16 +85,6 @@ context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
 ```
 
 The combined view merges named subjects by IRI and keeps the original graph views separate. `context.sources(subject, predicate, value)` can be used to inspect which graph contributed a subject, property, or specific property value.
-
-If a loader or middleware gives you a `Graph`, use `graph.context` to access the combined view for all graphs loaded into the same context:
-
-```javascript
-const graph = context.parse(profileTurtle, profileUrl, 'text/turtle')
-
-graph.data             // subjects from this one resource
-graph.context.data     // combined subjects from the whole context
-graph.context.get(id)  // merged subject from the whole context
-```
 
 For source-aware writes, use the graph-specific helpers when you know the resource you want to edit:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ OLDM is now structured as a small npm-workspaces monorepo. The split keeps the c
 | `@muze-nl/oldm-core` | Core object/graph mapping, helpers, and classes. Explicit ESM exports only. No N3 dependency and no global side effects. |
 | `@muze-nl/oldm-n3` | N3 parser/writer adapter for OLDM. Depends on `n3` and `@muze-nl/oldm-core`. |
 | `@muze-nl/oldm` | Beginner-friendly package. Exports one default `oldm` object, provides default N3 parser/writer wiring, browser bundles, and sets `globalThis.oldm`. |
-| `@muze-labs/oldm-shape` | Experimental assert-style object shapes for validating JavaScript objects and mapping them to and from OLDM objects. |
 
 ## Installation
 
@@ -41,12 +40,6 @@ const context = oldm({
 })
 ```
 
-For experimental object shapes:
-
-```shell
-npm install @muze-labs/oldm-shape @muze-nl/oldm-core @muze-nl/assert
-```
-
 
 ## Multiple graphs in one context
 
@@ -64,6 +57,8 @@ context.graphs                        // [profile, settings]
 context.graph(profileUrl)             // profile
 context.data                          // combined subject list
 context.subjects                      // combined subject map by full URI
+profile.context.data                  // same combined view, starting from a graph
+profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // [profile, settings] when both graphs contain data for that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
@@ -71,6 +66,16 @@ context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
 ```
 
 The combined view merges named subjects by IRI and keeps the original graph views separate. `context.sources(subject, predicate, value)` can be used to inspect which graph contributed a subject, property, or specific property value.
+
+If a loader or middleware gives you a `Graph`, use `graph.context` to access the combined view for all graphs loaded into the same context:
+
+```javascript
+const graph = context.parse(profileTurtle, profileUrl, 'text/turtle')
+
+graph.data             // subjects from this one resource
+graph.context.data     // combined subjects from the whole context
+graph.context.get(id)  // merged subject from the whole context
+```
 
 For source-aware writes, use the graph-specific helpers when you know the resource you want to edit:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-nl/oldm-workspace",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "private": true,
   "description": "Object - Linked Data Mapper monorepo",
   "type": "module",

--- a/packages/oldm-core/README.md
+++ b/packages/oldm-core/README.md
@@ -15,6 +15,27 @@ const context = oldm({
 ```
 
 
+## Prefix preference
+
+OLDM shortens predicate and type IRIs with the prefixes configured on the context. Prefix declarations found in Turtle input are parser conveniences; they do not decide the JavaScript property names exposed by OLDM.
+
+When multiple prefixes point at the same namespace, client-provided prefixes are preferred over OLDM defaults, and defaults are preferred over prefixes found in a parsed source document. For example, both `pim:` and `space:` are common aliases for `http://www.w3.org/ns/pim/space#`. Since OLDM prefers `space` for that namespace, profile data using either `pim:storage` or `space:storage` is exposed as `space$storage` in JavaScript.
+
+```javascript
+const context = oldm({
+  parser: n3Parser,
+  prefixes: {
+    space: 'http://www.w3.org/ns/pim/space#'
+  }
+})
+
+const profile = context.parse(turtle, profileUrl, 'text/turtle')
+const me = profile.subjects[`${profileUrl}#me`]
+
+console.log(me.space$storage.id)
+```
+
+
 ## Multiple graphs in one context
 
 `Context` keeps a registry of parsed graphs and exposes a combined view over all graphs loaded into the same context.
@@ -29,14 +50,14 @@ context.graphs                        // parsed graphs in load order
 context.graph(profileUrl)             // graph by source URL
 context.data                          // combined subjects
 context.subjects                      // combined subject map
-profile.context.data                  // same combined view, starting from a graph
-profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // graphs containing that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
 // graphs containing that property
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn', 'Auke')
 // graphs containing that specific value
+profile.context.data                  // same combined view, starting from a graph
+profile.context.subjects              // same combined subject map, starting from a graph
 ```
 
 The combined context view merges named subjects by IRI. Graph-specific views remain unchanged, so code can still separate data by original resource. Blank nodes remain graph-scoped.

--- a/packages/oldm-core/README.md
+++ b/packages/oldm-core/README.md
@@ -29,6 +29,8 @@ context.graphs                        // parsed graphs in load order
 context.graph(profileUrl)             // graph by source URL
 context.data                          // combined subjects
 context.subjects                      // combined subject map
+profile.context.data                  // same combined view, starting from a graph
+profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // graphs containing that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
@@ -38,6 +40,16 @@ context.sources(context.get(`${profileUrl}#me`), 'vcard$fn', 'Auke')
 ```
 
 The combined context view merges named subjects by IRI. Graph-specific views remain unchanged, so code can still separate data by original resource. Blank nodes remain graph-scoped.
+
+If a loader or middleware gives you a `Graph`, use `graph.context` to access the combined view for all graphs loaded into the same context:
+
+```javascript
+const graph = context.parse(profileTurtle, profileUrl, 'text/turtle')
+
+graph.data             // subjects from this one resource
+graph.context.data     // combined subjects from the whole context
+graph.context.get(id)  // merged subject from the whole context
+```
 
 For source-aware writes, use the graph-specific helpers when you know the resource you want to edit:
 

--- a/packages/oldm-core/package.json
+++ b/packages/oldm-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-nl/oldm-core",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Core Object - Linked Data Mapper, without parser or writer dependencies",
   "type": "module",
   "main": "src/oldm.mjs",

--- a/packages/oldm-core/src/oldm.mjs
+++ b/packages/oldm-core/src/oldm.mjs
@@ -183,9 +183,15 @@ export class Context {
 
 	constructor(options)
 	{
-		this.prefixes = {...prefixes, ...options?.prefixes} //FIXME: don't add the same url with different prefixes
-		if (!this.prefixes['xsd']) { //FIXME: don't assume the xsd url always has the 'xsd' prefix
+		const clientPrefixes = options?.prefixes ?? {}
+		this.prefixes = {...prefixes, ...clientPrefixes}
+		this.prefixOrder = [
+			...Object.keys(clientPrefixes),
+			...Object.keys(prefixes).filter(prefix => !(prefix in clientPrefixes))
+		]
+		if (!this.prefixes['xsd']) {
 			this.prefixes['xsd'] = 'http://www.w3.org/2001/XMLSchema#'
+			this.prefixOrder.push('xsd')
 		}
 		this.parser = options?.parser
 		this.writer = options?.writer
@@ -223,6 +229,7 @@ export class Context {
 
 				if (!this.prefixes[prefix]) {
 					this.prefixes[prefix] = prefixURL
+					this.prefixOrder.push(prefix)
 				}
 			}
 		}
@@ -511,7 +518,7 @@ export class Context {
 		if (!separator) {
 			separator = this.separator
 		}
-		for (let prefix in this.prefixes) {
+		for (const prefix of this.prefixOrder) {
 			if (fullURI.startsWith(this.prefixes[prefix])) {
 				return prefix + separator + fullURI.substring(this.prefixes[prefix].length)
 			}
@@ -795,7 +802,12 @@ export class Graph
 		}
 		const [prefix, path] = shortURI.split(separator)
 		if (path) {
-			return this.prefixes[prefix]+path 
+			if (this.context.prefixes[prefix]) {
+				return this.context.prefixes[prefix]+path
+			}
+			if (this.prefixes[prefix]) {
+				return this.prefixes[prefix]+path
+			}
 		}
 		return shortURI
 	}
@@ -805,7 +817,7 @@ export class Graph
 		if (!separator) {
 			separator = this.context.separator
 		}
-		for (let prefix in this.context.prefixes) {
+		for (const prefix of this.context.prefixOrder) {
 			if (fullURI.startsWith(this.context.prefixes[prefix])) {
 				return prefix + separator + fullURI.substring(this.context.prefixes[prefix].length)
 			}

--- a/packages/oldm-core/test/oldm-core.test.mjs
+++ b/packages/oldm-core/test/oldm-core.test.mjs
@@ -761,3 +761,44 @@ tap.test('direct assignment on the combined context view rejects ambiguous graph
 
 	t.end()
 })
+
+tap.test('client prefixes are preferred over source and default aliases when shortening predicates', t => {
+	const space = 'http://www.w3.org/ns/pim/space#'
+	const documentUrl = 'https://example.org/profile/card'
+	const me = `${documentUrl}#me`
+	const storage = 'https://example.org/'
+	const context = oldm({
+		parser() {
+			return {
+				quads: [quad(namedNode(me), namedNode(`${space}storage`), namedNode(storage))],
+				prefixes: {pim: space}
+			}
+		},
+		prefixes: {space}
+	})
+	const graph = context.parse('', documentUrl, 'text/turtle')
+
+	t.equal(graph.subjects[me].space$storage.id, storage)
+	t.equal(graph.subjects[me].pim$storage, undefined)
+	t.equal(context.subjects[me].space$storage.id, storage)
+	t.end()
+})
+
+tap.test('source-only prefixes are still available after client and default prefixes', t => {
+	const custom = 'https://example.org/ns#'
+	const documentUrl = 'https://example.org/data.ttl'
+	const subjectUrl = `${documentUrl}#item`
+	const context = oldm({
+		parser() {
+			return {
+				quads: [quad(namedNode(subjectUrl), namedNode(`${custom}score`), literal('10'))],
+				prefixes: {game: custom}
+			}
+		}
+	})
+	const graph = context.parse('', documentUrl, 'text/turtle')
+
+	t.equal(String(graph.subjects[subjectUrl].game$score), '10')
+	t.equal(String(context.subjects[subjectUrl].game$score), '10')
+	t.end()
+})

--- a/packages/oldm-core/test/oldm-core.test.mjs
+++ b/packages/oldm-core/test/oldm-core.test.mjs
@@ -302,14 +302,19 @@ tap.test('context registers parsed graphs and exposes a combined read view', t =
 	t.equal(context.graph(settingsUrl), settingsGraph)
 	t.equal(context.graphsByUrl[profileUrl], profile)
 	t.equal(context.graphsByUrl[settingsUrl], settingsGraph)
+	t.equal(profile.context, context)
+	t.equal(settingsGraph.context, context)
 
 	t.equal(context.get(profileUrl).id, profileUrl)
+	t.equal(profile.context.get(profileUrl).id, profileUrl)
 	t.equal(String(context.get(profileUrl).vcard$fn), 'Auke')
 	t.equal(context.get(settingsUrl).foaf$primaryTopic.id, profileUrl)
 	const subjects = context.subjects
 	t.equal(subjects[settingsUrl].foaf$primaryTopic, subjects[profileUrl])
 	t.equal(subjects[profileUrl].graph, context)
+	t.equal(profile.context.subjects[profileUrl].graph, context)
 	t.same(context.data.map(subject => subject.id).sort(), [profileUrl, settingsUrl, 'https://issuer.example/'].sort())
+	t.same(profile.context.data.map(subject => subject.id).sort(), context.data.map(subject => subject.id).sort())
 
 	// Graph views stay separate and unchanged.
 	t.equal(profile.get(profileUrl).graph, profile)

--- a/packages/oldm-n3/package.json
+++ b/packages/oldm-n3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-nl/oldm-n3",
-  "version": "0.5.3",
+  "version": "0.6.1",
   "description": "N3 parser and writer adapter for OLDM",
   "type": "module",
   "main": "src/oldm-n3.mjs",
@@ -20,7 +20,7 @@
   "author": "auke@muze.nl",
   "license": "MIT",
   "dependencies": {
-    "@muze-nl/oldm-core": "^0.5.3",
+    "@muze-nl/oldm-core": "^0.6.0",
     "n3": "^2.0.1"
   },
   "files": [

--- a/packages/oldm-shape/LICENSE
+++ b/packages/oldm-shape/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Muze.nl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/oldm-shape/MUZE_ALIGNMENT.md
+++ b/packages/oldm-shape/MUZE_ALIGNMENT.md
@@ -1,0 +1,105 @@
+# Muze alignment: @muze-labs/oldm-shape
+
+`@muze-labs/oldm-shape` is an experimental object-shape layer for OLDM.
+
+It is designed to let small browser applications define application-facing JavaScript object shapes, validate those objects, and convert them to and from OLDM linked data objects.
+
+## Alignment
+
+### Simplicity over completeness
+
+The package intentionally implements a small subset:
+
+- `shape()`
+- `field()`
+- `id()`
+- `uri()`
+- `typed()`
+- `node()`
+- `collection()`
+- `Optional()`
+- `Required()`
+
+It does not try to cover all RDF graph validation cases. That keeps the mental model close to normal JavaScript object validation.
+
+### Correct abstraction boundaries
+
+The package is not an ontology, not a parser, not a writer, not a Solid client, and not a form framework.
+
+Its boundary is:
+
+> assert-style JavaScript validation + explicit OLDM predicate mapping + graph/object conversion.
+
+That keeps OLDM core focused on object-linked-data mapping and keeps assert focused on lightweight validation.
+
+### Composable, decoupled components
+
+The package depends only on:
+
+- `@muze-nl/assert`
+- `@muze-nl/oldm-core`
+
+It does not depend on the N3 parser, the Turtle parser, Metro, Solid session handling, JSON-LD tooling, SHACL tooling, or ShEx tooling.
+
+### Browser and view-source friendliness
+
+The API is plain JavaScript and follows the existing assert style:
+
+```js
+const Contact = shape('vcard$Individual', {
+	id: id(uri()),
+	name: field('vcard$fn', String),
+	nickname: Optional(field('vcard$nickname', String))
+})
+```
+
+A technically curious non-professional programmer can inspect the shape and see both the JavaScript field names and the linked data predicates in one place.
+
+### Standards alignment
+
+The package uses OLDM short URIs and RDF concepts directly: subject ids, RDF type `a`, named nodes, blank nodes, typed literals, repeated predicate values, and RDF collections.
+
+It does not implement SHACL or ShEx in version 1. This is a deliberate tradeoff: SHACL and ShEx are better standards for RDF graph validation, but they are less direct as the application-facing JavaScript object mapping syntax.
+
+## Known divergences and future improvements
+
+### No SHACL or ShEx export yet
+
+The internal model is intentionally close to a small ShEx-like subset, but the package does not yet export SHACL or ShEx.
+
+Possible future packages or helpers:
+
+- `toShEx()`
+- `toShacl()`
+- `toJsonSchema()`
+
+These should remain optional so the core package stays small.
+
+### No advanced cardinality helpers yet
+
+Version 1 supports required values, optional values, repeated values with array patterns, and RDF collections.
+
+Possible future helpers:
+
+- `OneOrMore(pattern)`
+- `Min(count, pattern)`
+- `Max(count, pattern)`
+- `OneOf(...patterns)`
+
+These should only be added when concrete use cases need them.
+
+### No inference or graph-wide constraints
+
+The package validates and maps object-shaped data. It does not infer classes or validate arbitrary graph-wide relationships.
+
+SHACL, ShEx, RDFS, OWL, or custom queries are better fits for those cases.
+
+### Empty graph creation is still a little verbose
+
+Examples currently need to construct an empty OLDM graph directly:
+
+```js
+const graph = context.addGraph(new Graph([], url, 'text/turtle', context.prefixes, context))
+```
+
+A small `context.createGraph(url, type?)` helper in OLDM core would make this clearer and would benefit normal OLDM users too.

--- a/packages/oldm-shape/README.md
+++ b/packages/oldm-shape/README.md
@@ -21,6 +21,7 @@ import oldm, { Graph } from '@muze-nl/oldm-core'
 import {
 	Optional,
 	collection,
+	describe,
 	field,
 	id,
 	node,
@@ -75,8 +76,88 @@ subject.vcard$fn
 subject.vcard$hasEmail.vcard$value.id
 // 'mailto:auke@example.org'
 
-const plainObject = Contact.fromOldm(subject)
+const descriptor = describe(Contact)
+// or: Contact.describe()
 ```
+
+## Describing shapes
+
+`describe(shapeOrPattern)` returns a plain data descriptor for a shape or pattern.
+This is the public introspection API for tools that need to inspect a shape
+without depending on oldm-shape's private metadata.
+
+The descriptor is meant to be useful for later packages such as form generators,
+SHACL exporters, JSON Schema/OpenAPI adapters, and storage-schema mappers.
+
+```js
+const descriptor = describe(Contact)
+
+// simplified result:
+{
+	kind: 'shape',
+	type: 'vcard$Individual',
+	portable: true,
+	fields: {
+		id: {
+			kind: 'id',
+			key: 'id',
+			required: true,
+			optional: false,
+			cardinality: { min: 1, max: 1 },
+			value: { kind: 'uri', portable: true },
+			portable: true
+		},
+		name: {
+			kind: 'field',
+			key: 'name',
+			predicate: 'vcard$fn',
+			required: true,
+			optional: false,
+			cardinality: { min: 1, max: 1 },
+			value: { kind: 'literal', type: 'string', portable: true },
+			portable: true
+		},
+		nickname: {
+			kind: 'field',
+			key: 'nickname',
+			predicate: 'vcard$nickname',
+			required: false,
+			optional: true,
+			cardinality: { min: 0, max: 1 },
+			value: { kind: 'literal', type: 'string', portable: true },
+			portable: true
+		}
+	}
+}
+```
+
+A shape function also exposes the same descriptor through `.describe()`.
+
+```js
+Contact.describe()
+```
+
+Descriptors mark whether the pattern is portable. Built-in oldm-shape patterns
+such as `field()`, `id()`, `uri()`, `typed()`, `node()`, `collection()`,
+`Optional()`, `Required()`, JavaScript primitive constructors, regular
+expressions, and one-item array patterns are portable. Arbitrary JavaScript
+validator functions are still allowed for validation, but are described as
+custom non-portable patterns so schema converters can fail clearly instead of
+guessing.
+
+```js
+const Custom = shape('ex$Thing', {
+	name: field('ex$name', value => value ? false : 'missing')
+})
+
+describe(Custom).fields.name.value
+// { kind: 'custom', name: null, portable: false }
+```
+
+This package deliberately only describes the shape. Backend-specific decisions
+such as table names, join tables, indexes, migrations, or whether nested nodes
+become child tables or JSON columns should live in a separate mapping/profile
+layer.
 
 ## Prefixes
 
@@ -164,6 +245,20 @@ Contact.toOldm({ ...contact, extra: true }, graph, { extra: 'ignore' })
 ```
 
 ## API
+
+### `describe(shapeOrPattern)`
+
+Returns a plain descriptor for a shape or pattern. Use this when building tools
+on top of oldm-shape instead of reading private metadata from shape functions.
+
+```js
+const descriptor = describe(Contact)
+const sameDescriptor = Contact.describe()
+```
+
+The descriptor includes shape type, field keys, RDF predicates, id fields,
+required/optional state, cardinality, value kinds, datatypes, nested shapes, and
+`portable` flags.
 
 ### `shape(type?, fields, options?)`
 

--- a/packages/oldm-shape/README.md
+++ b/packages/oldm-shape/README.md
@@ -1,0 +1,343 @@
+# @muze-labs/oldm-shape
+
+`@muze-labs/oldm-shape` is a small assert-style shape layer for OLDM.
+
+It lets application code define a normal JavaScript object shape, validate JavaScript objects against that shape, and map those objects to and from OLDM linked data objects.
+
+The package is intentionally not SHACL, ShEx, JSON Schema, or an ontology language. It is a small application-facing mapper for object-shaped linked data.
+
+## Install
+
+```sh
+npm install @muze-labs/oldm-shape @muze-nl/oldm-core @muze-nl/assert
+```
+
+This package is experimental and currently lives in the `@muze-labs` namespace.
+
+## Basic use
+
+```js
+import oldm, { Graph } from '@muze-nl/oldm-core'
+import {
+	Optional,
+	collection,
+	field,
+	id,
+	node,
+	shape,
+	typed,
+	uri
+} from '@muze-labs/oldm-shape'
+
+const context = oldm()
+const graph = context.addGraph(new Graph(
+	[],
+	'https://example.org/contacts.ttl',
+	'text/turtle',
+	context.prefixes,
+	context
+))
+
+const Email = shape({
+	value: field('vcard$value', uri(/^mailto:/))
+})
+
+const Contact = shape('vcard$Individual', {
+	id: id(uri()),
+	name: field('vcard$fn', String),
+	nickname: Optional(field('vcard$nickname', String)),
+	birthday: Optional(field('vcard$bday', typed('xsd$date', /^\d{4}-\d{2}-\d{2}$/))),
+	email: Optional(field('vcard$hasEmail', node(Email))),
+	knows: Optional(field('foaf$knows', [uri()])),
+	topics: Optional(field('schema$knowsAbout', collection(String)))
+})
+
+const contact = {
+	id: 'https://example.org/profile/card#me',
+	name: 'Auke',
+	nickname: 'poef',
+	birthday: '1972-09-20',
+	email: {
+		value: 'mailto:auke@example.org'
+	},
+	knows: [
+		'https://example.org/alice#me',
+		'https://example.org/bob#me'
+	],
+	topics: ['web', 'solid']
+}
+
+const subject = Contact.toOldm(contact, graph)
+
+subject.vcard$fn
+// 'Auke'
+
+subject.vcard$hasEmail.vcard$value.id
+// 'mailto:auke@example.org'
+
+const plainObject = Contact.fromOldm(subject)
+```
+
+## Prefixes
+
+Shape definitions use OLDM short URIs such as `vcard$fn`, `foaf$knows`, or `ex$Contact`. Prefixes are not configured on the shape itself. Configure them on the OLDM context, then create graphs with that context.
+
+```js
+import oldm, { Graph } from '@muze-nl/oldm-core'
+
+const context = oldm({
+	prefixes: {
+		ex: 'https://example.org/ns#',
+		vcard: 'http://www.w3.org/2006/vcard/ns#'
+	}
+})
+
+const graph = context.addGraph(new Graph(
+	[],
+	'https://example.org/contacts.ttl',
+	'text/turtle',
+	context.prefixes,
+	context
+))
+
+const Contact = shape('ex$Contact', {
+	name: field('vcard$fn', String)
+})
+```
+
+OLDM already includes common prefixes such as `rdf`, `rdfs`, `xsd`, `foaf`, `schema`, `vcard`, `solid`, and `acl`. Add your own project or vocabulary prefixes to the context before converting shapes.
+
+`toOldm()` validates prefix use before writing anything to the graph. It throws when a short URI uses an unknown prefix, including shape types, field predicates, typed literal datatypes, `id(uri())` values, and `uri()` values.
+
+```js
+const Broken = shape('unknown$Thing', {
+	name: field('vcard$fn', String)
+})
+
+Broken.toOldm({ name: 'Auke' }, graph)
+// throws: unknown OLDM prefix "unknown"
+```
+
+## Validation
+
+A shape is a normal assertion function, so it can be used with `@muze-nl/assert`.
+
+```js
+import { assert, enable, fails } from '@muze-nl/assert'
+
+enable()
+
+assert(contact, Contact)
+
+const problems = fails(contact, Contact)
+```
+
+Each shape also exposes convenience methods:
+
+```js
+Contact.fails(contact)
+Contact.validate(contact)
+Contact.assert(contact)
+```
+
+By default validation follows the existing assert style and ignores extra JavaScript object fields:
+
+```js
+Contact.fails({ ...contact, extra: true })
+// false
+```
+
+You can make validation strict when you need that:
+
+```js
+Contact.fails({ ...contact, extra: true }, { extra: 'error' })
+```
+
+Conversion to OLDM is stricter by default because unknown JavaScript fields would otherwise be silently lost:
+
+```js
+Contact.toOldm({ ...contact, extra: true }, graph)
+// throws
+
+Contact.toOldm({ ...contact, extra: true }, graph, { extra: 'ignore' })
+// allowed
+```
+
+## API
+
+### `shape(type?, fields, options?)`
+
+Defines a shape. The optional `type` is mapped to the RDF type property `a`.
+
+```js
+const Person = shape('foaf$Person', {
+	id: id(uri()),
+	name: field('foaf$name', String)
+})
+```
+
+If the type is omitted, the shape can be used for blank nodes or untyped resources.
+
+```js
+const Note = shape({
+	text: field('schema$text', String)
+})
+```
+
+A shape function exposes:
+
+```js
+Person.fails(data, options?)
+Person.validate(data, options?)
+Person.assert(data, options?)
+Person.toOldm(data, graph, options?)
+Person.fromOldm(subject, options?)
+```
+
+### `field(predicate, pattern)`
+
+Maps a JavaScript property to an OLDM predicate.
+
+```js
+name: field('vcard$fn', String)
+```
+
+### `id(pattern = String)`
+
+Marks the JavaScript field that maps to the OLDM subject id.
+
+```js
+id: id(uri())
+```
+
+If a shape has no `id()` field, `toOldm()` creates a blank node.
+
+### `uri(pattern = uri-looking string)`
+
+Maps a JavaScript string to an OLDM named node.
+
+```js
+homepage: field('foaf$homepage', uri())
+emailValue: field('vcard$value', uri(/^mailto:/))
+```
+
+`uri()` accepts absolute URI strings, URL objects, and OLDM short URIs such as `foaf$Person`. It leaves URI normalization to OLDM so configured prefixes keep working.
+
+### `typed(datatype, pattern = String)`
+
+Maps a JavaScript literal to an OLDM typed literal.
+
+```js
+birthday: field('vcard$bday', typed('xsd$date', /^\d{4}-\d{2}-\d{2}$/))
+```
+
+Typed values are converted back to their primitive JavaScript value by `fromOldm()`.
+
+### `node(shapeOrFields)`
+
+Maps a nested JavaScript object to a nested OLDM node.
+
+```js
+const Email = shape({
+	value: field('vcard$value', uri(/^mailto:/))
+})
+
+const Contact = shape('vcard$Individual', {
+	email: field('vcard$hasEmail', node(Email))
+})
+```
+
+Nested shapes without an `id()` field are written as blank nodes. Nested shapes with an `id()` field are written as named subjects in the same graph.
+
+### Arrays for repeated predicate values
+
+Use assert's array style for repeated RDF predicate values:
+
+```js
+knows: field('foaf$knows', [uri()])
+```
+
+That maps this JavaScript object:
+
+```js
+{
+	knows: [
+		'https://example.org/alice#me',
+		'https://example.org/bob#me'
+	]
+}
+```
+
+to repeated `foaf$knows` values, not to an RDF collection.
+
+### `collection(pattern)`
+
+Use `collection()` when you intentionally want an RDF collection/list.
+
+```js
+topics: field('schema$knowsAbout', collection(String))
+```
+
+### `Optional(pattern)` and `Required(pattern)`
+
+These mirror the wrappers from `@muze-nl/assert`, but preserve the OLDM mapping metadata.
+
+```js
+nickname: Optional(field('vcard$nickname', String))
+name: Required(field('vcard$fn', String))
+```
+
+Use these wrappers from `@muze-labs/oldm-shape` around mapped fields. Validators from `@muze-nl/assert` can still be used inside fields.
+
+## Conversion rules
+
+`toOldm(data, graph, options?)`:
+
+- validates the JavaScript object first
+- writes only fields declared by the shape
+- writes the shape type to `a` when one is defined
+- creates a named subject when an `id()` field is present
+- creates a blank node when no `id()` field is present
+- treats unknown JavaScript fields as an error by default
+- does not fetch linked resources
+- does not infer predicates from JavaScript property names
+
+Options:
+
+```js
+Contact.toOldm(data, graph, {
+	extra: 'error',       // default; use 'ignore' to allow unknown JS fields
+	clearMissing: false  // default; true deletes missing mapped predicates
+})
+```
+
+`fromOldm(subject, options?)`:
+
+- projects only fields declared by the shape
+- ignores undeclared OLDM predicates
+- checks the RDF type by default when the shape has a type
+- rejects multiple RDF values for scalar JavaScript fields
+- validates the resulting JavaScript object before returning it
+
+Options:
+
+```js
+Contact.fromOldm(subject, {
+	requireType: true // default; false skips the RDF type check
+})
+```
+
+## Non-goals
+
+This package deliberately does not try to be:
+
+- SHACL
+- ShEx
+- JSON Schema
+- RDFS or OWL
+- a form framework
+- an inference engine
+- a Solid session or network layer
+- a JSON-LD processor
+
+Those tools may still be useful around OLDM. This package is only the small JavaScript object-shape and mapping layer.

--- a/packages/oldm-shape/package.json
+++ b/packages/oldm-shape/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@muze-labs/oldm-shape",
+  "version": "0.1.0",
+  "description": "Small assert-style object shapes for validating JavaScript objects and mapping them to OLDM linked data objects.",
+  "type": "module",
+  "main": "src/oldm-shape.mjs",
+  "exports": {
+    ".": "./src/oldm-shape.mjs"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "test": "tap --disable-coverage test/*.mjs",
+    "coverage": "tap --allow-incomplete-coverage --show-full-coverage test/*.mjs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/muze-nl/oldm.git",
+    "directory": "packages/oldm-shape"
+  },
+  "author": "auke@muze.nl",
+  "license": "MIT",
+  "dependencies": {
+    "@muze-nl/assert": "^0.5.1",
+    "@muze-nl/oldm-core": "^0.5.3"
+  },
+  "files": [
+    "src/",
+    "README.md",
+    "LICENSE",
+    "MUZE_ALIGNMENT.md"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/oldm-shape/package.json
+++ b/packages/oldm-shape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-labs/oldm-shape",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Small assert-style object shapes for validating JavaScript objects and mapping them to OLDM linked data objects.",
   "type": "module",
   "main": "src/oldm-shape.mjs",
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@muze-nl/assert": "^0.5.1",
-    "@muze-nl/oldm-core": "^0.5.3"
+    "@muze-nl/oldm-core": "^0.6.0"
   },
   "files": [
     "src/",

--- a/packages/oldm-shape/src/oldm-shape.mjs
+++ b/packages/oldm-shape/src/oldm-shape.mjs
@@ -32,7 +32,7 @@ export function shape(type, fields, options={})
 	}
 
 	const fieldEntries = Object.entries(fields)
-	const idEntry = fieldEntries.find(([, pattern]) => rootMeta(pattern)?.kind == 'id')
+	const idEntry = fieldEntries.find(([, pattern]) => mappingMeta(pattern)?.kind == 'id')
 	const info = {
 		kind: 'shape',
 		type,

--- a/packages/oldm-shape/src/oldm-shape.mjs
+++ b/packages/oldm-shape/src/oldm-shape.mjs
@@ -1,0 +1,729 @@
+import {
+	assert as assertValue,
+	error,
+	fails as assertFails
+} from '@muze-nl/assert'
+import {
+	BlankNode,
+	Collection,
+	Graph,
+	NamedNode
+} from '@muze-nl/oldm-core'
+
+const metadata = Symbol.for('@muze-labs/oldm-shape.metadata')
+
+let blankNodeId = 0
+
+/**
+ * Defines a JavaScript object shape that can validate application data and map
+ * it to and from OLDM objects.
+ *
+ * The optional type is written to and checked against the RDF type property `a`.
+ */
+export function shape(type, fields, options={})
+{
+	if (arguments.length == 1 || isPlainObject(type)) {
+		options = fields ?? {}
+		fields = type
+		type = null
+	}
+	if (!isPlainObject(fields)) {
+		throw new Error('shape() expects a field definition object')
+	}
+
+	const fieldEntries = Object.entries(fields)
+	const idEntry = fieldEntries.find(([, pattern]) => rootMeta(pattern)?.kind == 'id')
+	const info = {
+		kind: 'shape',
+		type,
+		fields,
+		options
+	}
+
+	function _shape(data, root, path='') {
+		return validateShape(data, info, root ?? data, path, { extra: 'ignore' })
+	}
+
+	Object.defineProperty(_shape, metadata, {
+		value: info,
+		enumerable: false
+	})
+
+	_shape.type = type
+	_shape.fields = fields
+	_shape.fails = (data, validateOptions={}) => validateShape(data, info, data, '', validateOptions)
+	_shape.validate = (data, validateOptions={}) => !_shape.fails(data, validateOptions)
+	_shape.assert = (data, validateOptions={}) => {
+		const problems = _shape.fails(data, validateOptions)
+		if (problems) {
+			throw shapeError('OLDM shape validation failed', problems, data)
+		}
+		return data
+	}
+	_shape.toOldm = (data, graph, convertOptions={}) => toOldm(info, data, graph, convertOptions, idEntry)
+	_shape.fromOldm = (subject, convertOptions={}) => fromOldm(info, subject, convertOptions)
+
+	return _shape
+}
+
+/**
+ * Maps a friendly JavaScript property to an OLDM predicate property.
+ */
+export function field(predicate, pattern)
+{
+	if (!predicate) {
+		throw new Error('field() expects an OLDM predicate such as vcard$fn')
+	}
+	function _field(data, root, path) {
+		return assertFails(data, pattern, root, path)
+	}
+	return withMeta(_field, {
+		kind: 'field',
+		predicate,
+		pattern
+	})
+}
+
+/**
+ * Marks the field that maps to the subject id.
+ */
+export function id(pattern=String)
+{
+	function _id(data, root, path) {
+		return assertFails(data, pattern, root, path)
+	}
+	return withMeta(_id, {
+		kind: 'id',
+		pattern
+	})
+}
+
+/**
+ * Maps a JavaScript string to an OLDM NamedNode.
+ */
+export function uri(pattern=looksLikeURI)
+{
+	function _uri(data, root, path) {
+		const problems = []
+		if (typeof data != 'string' && !(data instanceof String) && !(data instanceof URL)) {
+			problems.push(error('data is not a string, URL, or short URI', data, 'uri', path))
+			return problems
+		}
+		const value = data instanceof URL ? data.href : String(data)
+		const result = assertFails(value, pattern, root, path)
+		return result || false
+	}
+	return withMeta(_uri, {
+		kind: 'uri',
+		pattern
+	})
+}
+
+/**
+ * Maps a JavaScript literal value to an OLDM typed literal.
+ */
+export function typed(datatype, pattern=String)
+{
+	if (!datatype) {
+		throw new Error('typed() expects a datatype such as xsd$date')
+	}
+	function _typed(data, root, path) {
+		return assertFails(data, pattern, root, path)
+	}
+	return withMeta(_typed, {
+		kind: 'typed',
+		datatype,
+		pattern
+	})
+}
+
+/**
+ * Maps a nested JavaScript object to a nested OLDM node.
+ */
+export function node(nodeShape)
+{
+	if (isPlainObject(nodeShape)) {
+		nodeShape = shape(nodeShape)
+	}
+	if (!isShape(nodeShape)) {
+		throw new Error('node() expects a shape or field definition object')
+	}
+	function _node(data, root, path) {
+		return nodeShape(data, root, path)
+	}
+	return withMeta(_node, {
+		kind: 'node',
+		shape: nodeShape
+	})
+}
+
+/**
+ * Maps a JavaScript array to an RDF collection value.
+ */
+export function collection(pattern)
+{
+	function _collection(data, root, path) {
+		if (!Array.isArray(data)) {
+			return error('data is not an array', data, 'collection', path)
+		}
+		return assertFails(data, [pattern], root, path)
+	}
+	return withMeta(_collection, {
+		kind: 'collection',
+		pattern
+	})
+}
+
+/**
+ * Tests the wrapped pattern only when the value is not null or undefined.
+ *
+ * This mirrors @muze-nl/assert Optional(), but preserves OLDM mapping metadata.
+ */
+export function Optional(pattern)
+{
+	function _Optional(data, root, path) {
+		if (data != null && typeof data != 'undefined' && typeof pattern != 'undefined') {
+			return assertFails(data, pattern, root, path)
+		}
+	}
+	return withWrapperMeta(_Optional, pattern, { optional: true })
+}
+
+/**
+ * Tests the wrapped pattern and fails when the value is null or undefined.
+ *
+ * This mirrors @muze-nl/assert Required(), but preserves OLDM mapping metadata.
+ */
+export function Required(pattern)
+{
+	function _Required(data, root, path) {
+		if (data == null || typeof data == 'undefined') {
+			return error('data is required', data, pattern || 'any value', path)
+		}
+		if (typeof pattern != 'undefined') {
+			return assertFails(data, pattern, root, path)
+		}
+		return false
+	}
+	return withWrapperMeta(_Required, pattern, { required: true })
+}
+
+export function isShape(value)
+{
+	return rootMeta(value)?.kind == 'shape'
+}
+
+export function isDescriptor(value)
+{
+	return Boolean(rootMeta(value))
+}
+
+function validateShape(data, info, root, path='', options={})
+{
+	const problems = []
+	if (!data || typeof data != 'object' || Array.isArray(data)) {
+		problems.push(error('data is not an object', data, 'shape', path))
+		return problems
+	}
+
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		const result = assertFails(data[key], pattern, root, appendPath(path, key))
+		if (result) {
+			problems.push(...asProblems(result))
+		}
+	}
+
+	if (options.extra == 'error') {
+		for (const key of Object.keys(data)) {
+			if (!(key in info.fields)) {
+				problems.push(error('data contains a field that is not defined by this shape', data[key], 'no extra fields', appendPath(path, key)))
+			}
+		}
+	}
+
+	return problems.length ? problems : false
+}
+
+function toOldm(info, data, graph, options={}, idEntry)
+{
+	if (!(graph instanceof Graph)) {
+		throw new Error('toOldm() expects an OLDM Graph as its second argument')
+	}
+
+	const extra = options.extra ?? 'error'
+	const problems = validateShape(data, info, data, '', { extra })
+	if (problems) {
+		throw shapeError('OLDM shape validation failed', problems, data)
+	}
+
+	const prefixProblems = validatePrefixUse(info, data, graph)
+	if (prefixProblems) {
+		throw shapeError('OLDM shape prefix validation failed', prefixProblems, data)
+	}
+
+	const subject = createSubject(info, data, graph, idEntry)
+
+	if (info.type) {
+		graph.set(subject, 'a', info.type)
+	}
+
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		const meta = mappingMeta(pattern)
+		if (!meta || meta.kind == 'id') {
+			continue
+		}
+
+		const hasValue = Object.hasOwn(data, key) && data[key] != null
+		if (!hasValue) {
+			if (options.clearMissing && meta.predicate) {
+				graph.delete(subject, meta.predicate)
+			}
+			continue
+		}
+
+		const value = valueToOldm(meta.pattern, data[key], graph, options, key)
+		graph.set(subject, meta.predicate, value)
+	}
+
+	return subject
+}
+
+function fromOldm(info, subject, options={})
+{
+	if (!subject || typeof subject != 'object') {
+		throw new Error('fromOldm() expects an OLDM subject object')
+	}
+	if (info.type && options.requireType !== false && !hasType(subject, info.type)) {
+		const problems = [error('subject does not have the expected RDF type', subject.a, info.type, 'a')]
+		throw shapeError('OLDM shape conversion failed', problems, subject)
+	}
+
+	const data = {}
+	const problems = []
+
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		const meta = mappingMeta(pattern)
+		if (!meta) {
+			continue
+		}
+
+		if (meta.kind == 'id') {
+			if (subject.id) {
+				data[key] = subject.id
+			}
+			continue
+		}
+
+		const value = subject[meta.predicate]
+		if (value == null) {
+			continue
+		}
+
+		try {
+			data[key] = valueFromOldm(meta.pattern, value, options, key)
+		} catch(err) {
+			problems.push(error(err.message, value, meta.pattern, key))
+		}
+	}
+
+	const validation = validateShape(data, info, data, '', { extra: 'ignore' })
+	if (validation) {
+		problems.push(...validation)
+	}
+	if (problems.length) {
+		throw shapeError('OLDM shape conversion failed', problems, subject)
+	}
+
+	return data
+}
+
+
+function validatePrefixUse(info, data, graph)
+{
+	const problems = []
+	validatePatternPrefixes(info, graph, 'shape', problems)
+	validateDataPrefixes(info, data, graph, '', problems)
+	return problems.length ? problems : false
+}
+
+function validatePatternPrefixes(info, graph, path, problems)
+{
+	if (info.type) {
+		checkShortURIPrefix(info.type, graph, `${path}.type`, problems)
+	}
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		checkPatternPrefixes(pattern, graph, appendPath(path, key), problems)
+	}
+}
+
+function checkPatternPrefixes(pattern, graph, path, problems)
+{
+	const meta = rootMeta(pattern)
+	if (meta?.kind == 'optional' || meta?.kind == 'required') {
+		checkPatternPrefixes(meta.pattern, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'field') {
+		checkShortURIPrefix(meta.predicate, graph, `${path}.predicate`, problems)
+		checkPatternPrefixes(meta.pattern, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'id') {
+		checkPatternPrefixes(meta.pattern, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'typed') {
+		checkShortURIPrefix(meta.datatype, graph, `${path}.datatype`, problems)
+		checkPatternPrefixes(meta.pattern, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'node') {
+		const shapeInfo = rootMeta(meta.shape)
+		if (shapeInfo) {
+			validatePatternPrefixes(shapeInfo, graph, path, problems)
+		}
+		return
+	}
+	if (meta?.kind == 'collection') {
+		checkPatternPrefixes(meta.pattern, graph, path, problems)
+		return
+	}
+	if (Array.isArray(pattern) && pattern.length == 1) {
+		checkPatternPrefixes(pattern[0], graph, `${path}[]`, problems)
+	}
+}
+
+function validateDataPrefixes(info, data, graph, path, problems)
+{
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		const meta = mappingMeta(pattern)
+		if (!meta) {
+			continue
+		}
+
+		const value = data?.[key]
+		if (value == null) {
+			continue
+		}
+
+		const valuePath = appendPath(path, key)
+		if (meta.kind == 'id') {
+			checkShortURIPrefix(value, graph, valuePath, problems)
+		}
+		checkValuePrefixes(meta.pattern, value, graph, valuePath, problems)
+	}
+
+	if (info.options?.id && data?.[info.options.id]) {
+		checkShortURIPrefix(data[info.options.id], graph, info.options.id, problems)
+	}
+}
+
+function checkValuePrefixes(pattern, value, graph, path, problems)
+{
+	const meta = rootMeta(pattern)
+	if (meta?.kind == 'optional' || meta?.kind == 'required') {
+		checkValuePrefixes(meta.pattern, value, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'uri') {
+		checkShortURIPrefix(value, graph, path, problems)
+		return
+	}
+	if (meta?.kind == 'typed') {
+		return
+	}
+	if (meta?.kind == 'node') {
+		const shapeInfo = rootMeta(meta.shape)
+		if (shapeInfo) {
+			validateDataPrefixes(shapeInfo, value, graph, path, problems)
+		}
+		return
+	}
+	if (meta?.kind == 'collection') {
+		if (!Array.isArray(value)) {
+			return
+		}
+		for (const [index, item] of value.entries()) {
+			checkValuePrefixes(meta.pattern, item, graph, `${path}[${index}]`, problems)
+		}
+		return
+	}
+	if (Array.isArray(pattern) && pattern.length == 1 && Array.isArray(value)) {
+		for (const [index, item] of value.entries()) {
+			checkValuePrefixes(pattern[0], item, graph, `${path}[${index}]`, problems)
+		}
+	}
+}
+
+function checkShortURIPrefix(value, graph, path, problems)
+{
+	const shortURI = shortURIInfo(value, graph)
+	if (!shortURI || hasKnownPrefix(shortURI.prefix, graph)) {
+		return
+	}
+	problems.push(error(
+		`unknown OLDM prefix "${shortURI.prefix}"`,
+		String(value),
+		'known OLDM prefix',
+		path
+	))
+}
+
+function shortURIInfo(value, graph)
+{
+	if (value instanceof URL) {
+		return null
+	}
+	if (value instanceof NamedNode) {
+		return null
+	}
+	if (typeof value != 'string' && !(value instanceof String)) {
+		return null
+	}
+	const text = String(value)
+	if (/^[a-z][a-z0-9+.-]*:/i.test(text)) {
+		return null
+	}
+	const separator = graph?.context?.separator ?? '$'
+	const index = text.indexOf(separator)
+	if (index <= 0 || index == text.length - separator.length) {
+		return null
+	}
+	return {
+		prefix: text.slice(0, index),
+		path: text.slice(index + separator.length)
+	}
+}
+
+function hasKnownPrefix(prefix, graph)
+{
+	return Boolean(
+		graph?.context?.prefixes?.[prefix]
+		|| graph?.prefixes?.[prefix]
+	)
+}
+
+function createSubject(info, data, graph, idEntry)
+{
+	if (idEntry) {
+		const [key] = idEntry
+		if (data[key]) {
+			return graph.ensureSubject(data[key])
+		}
+	}
+	if (info.options?.id && data[info.options.id]) {
+		return graph.ensureSubject(data[info.options.id])
+	}
+	return graph.addBlankNode(`oldm-shape-${++blankNodeId}`)
+}
+
+function valueToOldm(pattern, value, graph, options, path)
+{
+	const meta = rootMeta(pattern)
+	if (meta?.kind == 'optional' || meta?.kind == 'required') {
+		return valueToOldm(meta.pattern, value, graph, options, path)
+	}
+	if (meta?.kind == 'uri') {
+		return value instanceof URL ? value.href : String(value)
+	}
+	if (meta?.kind == 'typed') {
+		return graph.setType(value, meta.datatype)
+	}
+	if (meta?.kind == 'node') {
+		return meta.shape.toOldm(value, graph, {
+			...options,
+			extra: options.extraNested ?? 'error'
+		})
+	}
+	if (meta?.kind == 'collection') {
+		const result = new Collection(graph)
+		for (const [index, item] of value.entries()) {
+			result.push(valueToOldm(meta.pattern, item, graph, options, `${path}[${index}]`))
+		}
+		return result
+	}
+	if (Array.isArray(pattern)) {
+		if (pattern.length != 1) {
+			throw new Error('OLDM shape array mappings need exactly one item pattern')
+		}
+		return value.map((item, index) => valueToOldm(pattern[0], item, graph, options, `${path}[${index}]`))
+	}
+	if (isShape(pattern)) {
+		throw new Error('Use node(shape) for nested OLDM object mappings')
+	}
+	return value
+}
+
+function valueFromOldm(pattern, value, options, path)
+{
+	const meta = rootMeta(pattern)
+	if (meta?.kind == 'optional' || meta?.kind == 'required') {
+		return valueFromOldm(meta.pattern, value, options, path)
+	}
+	if (meta?.kind == 'uri') {
+		return namedNodeID(value)
+	}
+	if (meta?.kind == 'typed') {
+		return literalValue(value)
+	}
+	if (meta?.kind == 'node') {
+		return meta.shape.fromOldm(value, options)
+	}
+	if (meta?.kind == 'collection') {
+		if (!(value instanceof Collection) && !Array.isArray(value)) {
+			throw new Error('expected an RDF collection value')
+		}
+		return [...value].map((item, index) => valueFromOldm(meta.pattern, item, options, `${path}[${index}]`))
+	}
+	if (Array.isArray(pattern)) {
+		if (pattern.length != 1) {
+			throw new Error('OLDM shape array mappings need exactly one item pattern')
+		}
+		return manyOldm(value).map((item, index) => valueFromOldm(pattern[0], item, options, `${path}[${index}]`))
+	}
+	if (Array.isArray(value) && !(value instanceof Collection)) {
+		throw new Error('expected one value but found multiple values')
+	}
+	return literalValue(value)
+}
+
+function mappingMeta(pattern)
+{
+	const meta = rootMeta(pattern)
+	if (!meta) {
+		return null
+	}
+	if (meta.kind == 'field') {
+		return meta
+	}
+	if ((meta.kind == 'optional' || meta.kind == 'required') && rootMeta(meta.pattern)?.kind == 'field') {
+		return {
+			...rootMeta(meta.pattern),
+			optional: meta.optional,
+			required: meta.required
+		}
+	}
+	if (meta.kind == 'id') {
+		return meta
+	}
+	if ((meta.kind == 'optional' || meta.kind == 'required') && rootMeta(meta.pattern)?.kind == 'id') {
+		return rootMeta(meta.pattern)
+	}
+	return null
+}
+
+function rootMeta(value)
+{
+	return value?.[metadata] ?? null
+}
+
+function withMeta(fn, meta)
+{
+	Object.defineProperty(fn, metadata, {
+		value: meta,
+		enumerable: false
+	})
+	return fn
+}
+
+function withWrapperMeta(fn, pattern, extras)
+{
+	const child = rootMeta(pattern)
+	return withMeta(fn, {
+		kind: extras.optional ? 'optional' : 'required',
+		pattern,
+		...extras,
+		child
+	})
+}
+
+function hasType(subject, type)
+{
+	if (!type) {
+		return true
+	}
+	const types = manyOldm(subject.a)
+	return types.some(item => item == type || item?.id == type)
+}
+
+function namedNodeID(value)
+{
+	if (value instanceof NamedNode || value?.id) {
+		return value.id
+	}
+	return String(value)
+}
+
+function literalValue(value)
+{
+	if (value instanceof String || value instanceof Number || value instanceof Boolean) {
+		return value.valueOf()
+	}
+	return value
+}
+
+function manyOldm(value)
+{
+	if (Array.isArray(value) && !(value instanceof Collection)) {
+		return value
+	}
+	if (value == null) {
+		return []
+	}
+	return [value]
+}
+
+function asProblems(result)
+{
+	return Array.isArray(result) ? result : [result]
+}
+
+function appendPath(path, key)
+{
+	return path ? `${path}.${key}` : key
+}
+
+function shapeError(message, problems, source)
+{
+	return new Error(message, {
+		cause: {
+			problems,
+			source
+		}
+	})
+}
+
+function looksLikeURI(data, root, path)
+{
+	if (typeof data != 'string' && !(data instanceof String) && !(data instanceof URL)) {
+		return error('data is not a URI string', data, 'uri', path)
+	}
+	const value = data instanceof URL ? data.href : String(data)
+	if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+		return false
+	}
+	if (/^[a-z][a-z0-9_-]*\$.+$/i.test(value)) {
+		return false
+	}
+	return error('data does not look like an absolute or short URI', data, 'uri', path)
+}
+
+function isPlainObject(value)
+{
+	return Boolean(value) && typeof value == 'object' && value.constructor == Object
+}
+
+export default {
+	shape,
+	field,
+	id,
+	uri,
+	typed,
+	node,
+	collection,
+	Optional,
+	Required,
+	isShape,
+	isDescriptor,
+	assert: assertValue
+}

--- a/packages/oldm-shape/src/oldm-shape.mjs
+++ b/packages/oldm-shape/src/oldm-shape.mjs
@@ -306,133 +306,164 @@ function describeShapeField(key, pattern, ctx)
 	})
 }
 
+const metaDescriptorRegistry = new Map()
+const patternDescriptorRegistry = []
+
+function registerMetaDescriptor(kind, handler)
+{
+	metaDescriptorRegistry.set(kind, handler)
+}
+
+function registerPatternDescriptor(test, handler)
+{
+	patternDescriptorRegistry.push({ test, handler })
+}
+
+registerMetaDescriptor('shape', (pattern, meta, ctx) => describeShape(meta, ctx))
+
+registerMetaDescriptor('optional', describeWrapperPattern)
+registerMetaDescriptor('required', describeWrapperPattern)
+
+registerMetaDescriptor('field', (pattern, meta, ctx) => withPortable({
+	kind: 'field-pattern',
+	predicate: meta.predicate,
+	value: describePattern(meta.pattern, ctx)
+}))
+
+registerMetaDescriptor('id', (pattern, meta, ctx) => withPortable({
+	kind: 'id-pattern',
+	value: describePattern(meta.pattern, ctx)
+}))
+
+registerMetaDescriptor('uri', (pattern, meta, ctx) => {
+	const descriptor = {
+		kind: 'uri'
+	}
+	if (meta.pattern && meta.pattern !== looksLikeURI) {
+		descriptor.value = describePattern(meta.pattern, ctx)
+	}
+	return withPortable(descriptor)
+})
+
+registerMetaDescriptor('typed', (pattern, meta, ctx) => withPortable({
+	kind: 'typed',
+	datatype: meta.datatype,
+	value: describePattern(meta.pattern, ctx)
+}))
+
+registerMetaDescriptor('node', (pattern, meta, ctx) => withPortable({
+	kind: 'node',
+	shape: describePattern(meta.shape, ctx)
+}))
+
+registerMetaDescriptor('collection', (pattern, meta, ctx) => withPortable({
+	kind: 'collection',
+	ordered: true,
+	item: describePattern(meta.pattern, ctx)
+}))
+
+registerPatternDescriptor(Array.isArray, describeArrayPattern)
+registerPatternDescriptor(pattern => pattern === String, () => literalDescriptor('string'))
+registerPatternDescriptor(pattern => pattern === Number, () => literalDescriptor('number'))
+registerPatternDescriptor(pattern => pattern === Boolean, () => literalDescriptor('boolean'))
+registerPatternDescriptor(pattern => pattern instanceof RegExp, describeRegExpPattern)
+registerPatternDescriptor(isPlainObject, describeObjectPattern)
+registerPatternDescriptor(pattern => typeof pattern == 'function', describeFunctionPattern)
+registerPatternDescriptor(pattern => pattern == null || isJSONValue(pattern), describeConstantPattern)
+
 function describePattern(pattern, ctx)
 {
 	const meta = rootMeta(pattern)
-
-	if (meta?.kind == 'shape') {
-		return describeShape(meta, ctx)
-	}
-	if (meta?.kind == 'optional' || meta?.kind == 'required') {
-		return withPortable({
-			kind: meta.kind,
-			value: describePattern(meta.pattern, ctx)
-		})
-	}
-	if (meta?.kind == 'field') {
-		return withPortable({
-			kind: 'field-pattern',
-			predicate: meta.predicate,
-			value: describePattern(meta.pattern, ctx)
-		})
-	}
-	if (meta?.kind == 'id') {
-		return withPortable({
-			kind: 'id-pattern',
-			value: describePattern(meta.pattern, ctx)
-		})
-	}
-	if (meta?.kind == 'uri') {
-		const descriptor = {
-			kind: 'uri'
+	if (meta) {
+		const handler = metaDescriptorRegistry.get(meta.kind)
+		if (handler) {
+			return handler(pattern, meta, ctx)
 		}
-		if (meta.pattern && meta.pattern !== looksLikeURI) {
-			descriptor.value = describePattern(meta.pattern, ctx)
-		}
-		return withPortable(descriptor)
-	}
-	if (meta?.kind == 'typed') {
-		return withPortable({
-			kind: 'typed',
-			datatype: meta.datatype,
-			value: describePattern(meta.pattern, ctx)
-		})
-	}
-	if (meta?.kind == 'node') {
-		return withPortable({
-			kind: 'node',
-			shape: describePattern(meta.shape, ctx)
-		})
-	}
-	if (meta?.kind == 'collection') {
-		return withPortable({
-			kind: 'collection',
-			ordered: true,
-			item: describePattern(meta.pattern, ctx)
-		})
 	}
 
-	if (Array.isArray(pattern)) {
-		if (pattern.length == 1) {
-			return withPortable({
-				kind: 'array',
-				item: describePattern(pattern[0], ctx)
-			})
-		}
-		return {
-			kind: 'tuple',
-			items: pattern.map(item => describePattern(item, ctx)),
-			portable: false
+	for (const { test, handler } of patternDescriptorRegistry) {
+		if (test(pattern)) {
+			return handler(pattern, ctx)
 		}
 	}
-	if (pattern === String) {
-		return {
-			kind: 'literal',
-			type: 'string',
-			portable: true
-		}
-	}
-	if (pattern === Number) {
-		return {
-			kind: 'literal',
-			type: 'number',
-			portable: true
-		}
-	}
-	if (pattern === Boolean) {
-		return {
-			kind: 'literal',
-			type: 'boolean',
-			portable: true
-		}
-	}
-	if (pattern instanceof RegExp) {
-		return {
-			kind: 'regexp',
-			source: pattern.source,
-			flags: pattern.flags,
-			portable: true
-		}
-	}
-	if (isPlainObject(pattern)) {
-		const fields = {}
-		for (const [key, value] of Object.entries(pattern)) {
-			fields[key] = describePattern(value, ctx)
-		}
-		return {
-			kind: 'object',
-			fields,
-			portable: fieldsPortable(fields)
-		}
-	}
-	if (typeof pattern == 'function') {
-		return {
-			kind: 'custom',
-			name: pattern.name || null,
-			portable: false
-		}
-	}
-	if (pattern == null || isJSONValue(pattern)) {
-		return {
-			kind: 'constant',
-			value: pattern,
-			portable: true
-		}
-	}
+
 	return {
 		kind: 'unknown',
 		name: Object.prototype.toString.call(pattern),
 		portable: false
+	}
+}
+
+function describeWrapperPattern(pattern, meta, ctx)
+{
+	return withPortable({
+		kind: meta.kind,
+		value: describePattern(meta.pattern, ctx)
+	})
+}
+
+function describeArrayPattern(pattern, ctx)
+{
+	if (pattern.length == 1) {
+		return withPortable({
+			kind: 'array',
+			item: describePattern(pattern[0], ctx)
+		})
+	}
+	return {
+		kind: 'tuple',
+		items: pattern.map(item => describePattern(item, ctx)),
+		portable: false
+	}
+}
+
+function literalDescriptor(type)
+{
+	return {
+		kind: 'literal',
+		type,
+		portable: true
+	}
+}
+
+function describeRegExpPattern(pattern)
+{
+	return {
+		kind: 'regexp',
+		source: pattern.source,
+		flags: pattern.flags,
+		portable: true
+	}
+}
+
+function describeObjectPattern(pattern, ctx)
+{
+	const fields = {}
+	for (const [key, value] of Object.entries(pattern)) {
+		fields[key] = describePattern(value, ctx)
+	}
+	return {
+		kind: 'object',
+		fields,
+		portable: fieldsPortable(fields)
+	}
+}
+
+function describeFunctionPattern(pattern)
+{
+	return {
+		kind: 'custom',
+		name: pattern.name || null,
+		portable: false
+	}
+}
+
+function describeConstantPattern(pattern)
+{
+	return {
+		kind: 'constant',
+		value: pattern,
+		portable: true
 	}
 }
 

--- a/packages/oldm-shape/src/oldm-shape.mjs
+++ b/packages/oldm-shape/src/oldm-shape.mjs
@@ -60,6 +60,7 @@ export function shape(type, fields, options={})
 		}
 		return data
 	}
+	_shape.describe = () => describe(_shape)
 	_shape.toOldm = (data, graph, convertOptions={}) => toOldm(info, data, graph, convertOptions, idEntry)
 	_shape.fromOldm = (subject, convertOptions={}) => fromOldm(info, subject, convertOptions)
 
@@ -216,6 +217,342 @@ export function isShape(value)
 export function isDescriptor(value)
 {
 	return Boolean(rootMeta(value))
+}
+
+
+/**
+ * Returns a plain descriptor for a shape or pattern.
+ *
+ * The descriptor is intentionally data-only. It exposes the mapping metadata
+ * that converters, form generators, and schema exporters need without making
+ * them depend on the private metadata symbol used internally by oldm-shape.
+ */
+export function describe(value)
+{
+	const descriptor = describePattern(value, { seen: new Map() })
+	if (!descriptor) {
+		throw new Error('describe() expects an oldm-shape shape or pattern')
+	}
+	return descriptor
+}
+
+
+function describeShape(info, ctx)
+{
+	if (ctx.seen.has(info)) {
+		return {
+			kind: 'shape-ref',
+			type: info.type ?? null
+		}
+	}
+
+	ctx.seen.set(info, true)
+	const fields = {}
+	for (const [key, pattern] of Object.entries(info.fields)) {
+		fields[key] = describeShapeField(key, pattern, ctx)
+	}
+	ctx.seen.delete(info)
+
+	const descriptor = {
+		kind: 'shape',
+		type: info.type ?? null,
+		fields,
+		options: describeOptions(info.options)
+	}
+	descriptor.portable = fieldsPortable(fields)
+	return descriptor
+}
+
+function describeShapeField(key, pattern, ctx)
+{
+	const presence = describePresence(pattern)
+	const unwrapped = unwrapWrappers(pattern)
+	const meta = rootMeta(unwrapped)
+
+	if (meta?.kind == 'field') {
+		const value = describePattern(meta.pattern, ctx)
+		return withPortable({
+			kind: 'field',
+			key,
+			predicate: meta.predicate,
+			required: presence.required,
+			optional: presence.optional,
+			cardinality: cardinalityFor(value, presence),
+			value
+		})
+	}
+
+	if (meta?.kind == 'id') {
+		const value = describePattern(meta.pattern, ctx)
+		return withPortable({
+			kind: 'id',
+			key,
+			required: presence.required,
+			optional: presence.optional,
+			cardinality: cardinalityFor(value, presence),
+			value
+		})
+	}
+
+	const value = describePattern(pattern, ctx)
+	return withPortable({
+		kind: 'validator',
+		key,
+		required: presence.required,
+		optional: presence.optional,
+		cardinality: cardinalityFor(value, presence),
+		mapped: false,
+		value
+	})
+}
+
+function describePattern(pattern, ctx)
+{
+	const meta = rootMeta(pattern)
+
+	if (meta?.kind == 'shape') {
+		return describeShape(meta, ctx)
+	}
+	if (meta?.kind == 'optional' || meta?.kind == 'required') {
+		return withPortable({
+			kind: meta.kind,
+			value: describePattern(meta.pattern, ctx)
+		})
+	}
+	if (meta?.kind == 'field') {
+		return withPortable({
+			kind: 'field-pattern',
+			predicate: meta.predicate,
+			value: describePattern(meta.pattern, ctx)
+		})
+	}
+	if (meta?.kind == 'id') {
+		return withPortable({
+			kind: 'id-pattern',
+			value: describePattern(meta.pattern, ctx)
+		})
+	}
+	if (meta?.kind == 'uri') {
+		const descriptor = {
+			kind: 'uri'
+		}
+		if (meta.pattern && meta.pattern !== looksLikeURI) {
+			descriptor.value = describePattern(meta.pattern, ctx)
+		}
+		return withPortable(descriptor)
+	}
+	if (meta?.kind == 'typed') {
+		return withPortable({
+			kind: 'typed',
+			datatype: meta.datatype,
+			value: describePattern(meta.pattern, ctx)
+		})
+	}
+	if (meta?.kind == 'node') {
+		return withPortable({
+			kind: 'node',
+			shape: describePattern(meta.shape, ctx)
+		})
+	}
+	if (meta?.kind == 'collection') {
+		return withPortable({
+			kind: 'collection',
+			ordered: true,
+			item: describePattern(meta.pattern, ctx)
+		})
+	}
+
+	if (Array.isArray(pattern)) {
+		if (pattern.length == 1) {
+			return withPortable({
+				kind: 'array',
+				item: describePattern(pattern[0], ctx)
+			})
+		}
+		return {
+			kind: 'tuple',
+			items: pattern.map(item => describePattern(item, ctx)),
+			portable: false
+		}
+	}
+	if (pattern === String) {
+		return {
+			kind: 'literal',
+			type: 'string',
+			portable: true
+		}
+	}
+	if (pattern === Number) {
+		return {
+			kind: 'literal',
+			type: 'number',
+			portable: true
+		}
+	}
+	if (pattern === Boolean) {
+		return {
+			kind: 'literal',
+			type: 'boolean',
+			portable: true
+		}
+	}
+	if (pattern instanceof RegExp) {
+		return {
+			kind: 'regexp',
+			source: pattern.source,
+			flags: pattern.flags,
+			portable: true
+		}
+	}
+	if (isPlainObject(pattern)) {
+		const fields = {}
+		for (const [key, value] of Object.entries(pattern)) {
+			fields[key] = describePattern(value, ctx)
+		}
+		return {
+			kind: 'object',
+			fields,
+			portable: fieldsPortable(fields)
+		}
+	}
+	if (typeof pattern == 'function') {
+		return {
+			kind: 'custom',
+			name: pattern.name || null,
+			portable: false
+		}
+	}
+	if (pattern == null || isJSONValue(pattern)) {
+		return {
+			kind: 'constant',
+			value: pattern,
+			portable: true
+		}
+	}
+	return {
+		kind: 'unknown',
+		name: Object.prototype.toString.call(pattern),
+		portable: false
+	}
+}
+
+function describePresence(pattern)
+{
+	const meta = rootMeta(pattern)
+	if (meta?.kind == 'optional') {
+		return {
+			optional: true,
+			required: false,
+			explicit: true
+		}
+	}
+	if (meta?.kind == 'required') {
+		return {
+			optional: false,
+			required: true,
+			explicit: true
+		}
+	}
+	return {
+		optional: false,
+		required: true,
+		explicit: false
+	}
+}
+
+function unwrapWrappers(pattern)
+{
+	let result = pattern
+	let meta = rootMeta(result)
+	while (meta?.kind == 'optional' || meta?.kind == 'required') {
+		result = meta.pattern
+		meta = rootMeta(result)
+	}
+	return result
+}
+
+function cardinalityFor(value, presence)
+{
+	return {
+		min: presence.required ? 1 : 0,
+		max: value?.kind == 'array' || value?.kind == 'collection' ? null : 1
+	}
+}
+
+function withPortable(descriptor)
+{
+	descriptor.portable = descriptorPortable(descriptor)
+	return descriptor
+}
+
+function descriptorPortable(descriptor)
+{
+	if (!descriptor) {
+		return false
+	}
+	if (descriptor.portable === false) {
+		return false
+	}
+	if (descriptor.value && descriptor.value.portable === false) {
+		return false
+	}
+	if (descriptor.item && descriptor.item.portable === false) {
+		return false
+	}
+	if (descriptor.shape && descriptor.shape.portable === false) {
+		return false
+	}
+	if (descriptor.fields && !fieldsPortable(descriptor.fields)) {
+		return false
+	}
+	return true
+}
+
+function fieldsPortable(fields)
+{
+	return Object.values(fields).every(field => descriptorPortable(field))
+}
+
+function describeOptions(options)
+{
+	if (!options || !Object.keys(options).length) {
+		return {}
+	}
+	return describeOptionValue(options)
+}
+
+function describeOptionValue(value)
+{
+	if (Array.isArray(value)) {
+		return value.map(describeOptionValue)
+	}
+	if (isPlainObject(value)) {
+		const result = {}
+		for (const [key, item] of Object.entries(value)) {
+			result[key] = describeOptionValue(item)
+		}
+		return result
+	}
+	if (isJSONValue(value)) {
+		return value
+	}
+	if (typeof value == 'function') {
+		return {
+			kind: 'function',
+			name: value.name || null,
+			portable: false
+		}
+	}
+	return {
+		kind: 'value',
+		name: Object.prototype.toString.call(value),
+		portable: false
+	}
+}
+
+function isJSONValue(value)
+{
+	return value === null || ['string', 'number', 'boolean'].includes(typeof value)
 }
 
 function validateShape(data, info, root, path='', options={})
@@ -723,6 +1060,7 @@ export default {
 	collection,
 	Optional,
 	Required,
+	describe,
 	isShape,
 	isDescriptor,
 	assert: assertValue

--- a/packages/oldm-shape/test/oldm-shape.test.mjs
+++ b/packages/oldm-shape/test/oldm-shape.test.mjs
@@ -5,6 +5,7 @@ import {
 	Optional,
 	Required,
 	collection,
+	describe,
 	field,
 	id,
 	node,
@@ -65,6 +66,84 @@ tap.test('shape works as an assert-compatible validator', t => {
 	t.notOk(Contact.fails({...contact, extra: true}))
 	t.ok(Contact.fails({...contact, extra: true}, { extra: 'error' }))
 
+	t.end()
+})
+
+
+
+tap.test('describe exposes a stable data-only shape descriptor', t => {
+	const descriptor = describe(Contact)
+
+	t.equal(descriptor.kind, 'shape')
+	t.equal(descriptor.type, 'vcard$Individual')
+	t.equal(descriptor.portable, true)
+
+	t.same(descriptor.fields.id, {
+		kind: 'id',
+		key: 'id',
+		required: true,
+		optional: false,
+		cardinality: { min: 1, max: 1 },
+		value: {
+			kind: 'uri',
+			portable: true
+		},
+		portable: true
+	})
+
+	t.same(descriptor.fields.name, {
+		kind: 'field',
+		key: 'name',
+		predicate: 'vcard$fn',
+		required: true,
+		optional: false,
+		cardinality: { min: 1, max: 1 },
+		value: {
+			kind: 'literal',
+			type: 'string',
+			portable: true
+		},
+		portable: true
+	})
+
+	t.same(descriptor.fields.nickname, {
+		kind: 'field',
+		key: 'nickname',
+		predicate: 'vcard$nickname',
+		required: false,
+		optional: true,
+		cardinality: { min: 0, max: 1 },
+		value: {
+			kind: 'literal',
+			type: 'string',
+			portable: true
+		},
+		portable: true
+	})
+
+	t.equal(descriptor.fields.birthday.value.kind, 'typed')
+	t.equal(descriptor.fields.birthday.value.datatype, 'xsd$date')
+	t.same(descriptor.fields.birthday.value.value, {
+		kind: 'regexp',
+		source: '^\\d{4}-\\d{2}-\\d{2}$',
+		flags: '',
+		portable: true
+	})
+
+	t.equal(descriptor.fields.email.value.kind, 'node')
+	t.equal(descriptor.fields.email.value.shape.kind, 'shape')
+	t.equal(descriptor.fields.email.value.shape.fields.value.predicate, 'vcard$value')
+
+	t.same(descriptor.fields.knows.cardinality, { min: 0, max: null })
+	t.equal(descriptor.fields.knows.value.kind, 'array')
+	t.equal(descriptor.fields.knows.value.item.kind, 'uri')
+
+	t.same(descriptor.fields.topics.cardinality, { min: 0, max: null })
+	t.equal(descriptor.fields.topics.value.kind, 'collection')
+	t.equal(descriptor.fields.topics.value.item.type, 'string')
+
+	t.same(Contact.describe(), descriptor)
+	t.same(describe(String), { kind: 'literal', type: 'string', portable: true })
 	t.end()
 })
 

--- a/packages/oldm-shape/test/oldm-shape.test.mjs
+++ b/packages/oldm-shape/test/oldm-shape.test.mjs
@@ -1,0 +1,198 @@
+import tap from 'tap'
+import { fails } from '@muze-nl/assert'
+import oldm, { Collection, Graph, NamedNode } from '@muze-nl/oldm-core'
+import {
+	Optional,
+	Required,
+	collection,
+	field,
+	id,
+	node,
+	shape,
+	typed,
+	uri
+} from '@muze-labs/oldm-shape'
+
+function graphFor(url='https://example.org/contacts.ttl') {
+	const context = oldm({
+		prefixes: {
+			foaf: 'http://xmlns.com/foaf/0.1/',
+			schema: 'http://schema.org/',
+			vcard: 'http://www.w3.org/2006/vcard/ns#',
+			xsd: 'http://www.w3.org/2001/XMLSchema#'
+		}
+	})
+	return context.addGraph(new Graph([], url, 'text/turtle', context.prefixes, context))
+}
+
+const Email = shape({
+	value: field('vcard$value', uri(/^mailto:/))
+})
+
+const Contact = shape('vcard$Individual', {
+	id: id(uri()),
+	name: field('vcard$fn', String),
+	nickname: Optional(field('vcard$nickname', String)),
+	birthday: Optional(field('vcard$bday', typed('xsd$date', /^\d{4}-\d{2}-\d{2}$/))),
+	email: Optional(field('vcard$hasEmail', node(Email))),
+	knows: Optional(field('foaf$knows', [uri()])),
+	topics: Optional(field('schema$knowsAbout', collection(String)))
+})
+
+const contact = {
+	id: 'https://example.org/profile/card#me',
+	name: 'Auke',
+	nickname: 'poef',
+	birthday: '1972-09-20',
+	email: {
+		value: 'mailto:auke@example.org'
+	},
+	knows: [
+		'https://example.org/alice#me',
+		'https://example.org/bob#me'
+	],
+	topics: ['web', 'solid']
+}
+
+tap.test('shape works as an assert-compatible validator', t => {
+	t.notOk(fails(contact, Contact))
+	t.notOk(Contact.fails(contact))
+
+	const problems = Contact.fails({...contact, name: ''})
+	t.ok(problems)
+	t.equal(problems[0].path, 'name')
+
+	t.notOk(Contact.fails({...contact, extra: true}))
+	t.ok(Contact.fails({...contact, extra: true}, { extra: 'error' }))
+
+	t.end()
+})
+
+tap.test('toOldm maps JavaScript objects to OLDM subjects', t => {
+	const graph = graphFor()
+	const subject = Contact.toOldm(contact, graph)
+
+	t.equal(subject.id, contact.id)
+	t.equal(subject.a, 'vcard$Individual')
+	t.equal(String(subject.vcard$fn), 'Auke')
+	t.equal(String(subject.vcard$nickname), 'poef')
+	t.equal(String(subject.vcard$bday), '1972-09-20')
+	t.equal(subject.vcard$bday.type, 'xsd$date')
+	t.equal(subject.vcard$hasEmail.vcard$value.id, 'mailto:auke@example.org')
+	t.ok(subject.foaf$knows[0] instanceof NamedNode)
+	t.same(subject.foaf$knows.map(value => value.id), contact.knows)
+	t.ok(subject.schema$knowsAbout instanceof Collection)
+	t.same([...subject.schema$knowsAbout].map(String), ['web', 'solid'])
+
+	t.end()
+})
+
+tap.test('toOldm rejects extra fields by default during conversion', t => {
+	const graph = graphFor()
+	t.throws(() => Contact.toOldm({...contact, unknown: true}, graph), /OLDM shape validation failed/)
+	t.doesNotThrow(() => Contact.toOldm({...contact, unknown: true}, graph, { extra: 'ignore' }))
+	t.end()
+})
+
+
+
+tap.test('toOldm rejects unknown prefixes before writing to the graph', t => {
+	const graph = graphFor()
+
+	const UnknownType = shape('unknown$Thing', {
+		name: field('vcard$fn', String)
+	})
+	t.throws(() => UnknownType.toOldm({ name: 'Auke' }, graph), /OLDM shape prefix validation failed/)
+
+	const UnknownPredicate = shape('vcard$Individual', {
+		name: field('unknown$name', String)
+	})
+	t.throws(() => UnknownPredicate.toOldm({ name: 'Auke' }, graph), /OLDM shape prefix validation failed/)
+
+	const UnknownDatatype = shape('vcard$Individual', {
+		date: field('vcard$bday', typed('unknown$date', String))
+	})
+	t.throws(() => UnknownDatatype.toOldm({ date: '2026-06-24' }, graph), /OLDM shape prefix validation failed/)
+
+	const UnknownIdValue = shape('vcard$Individual', {
+		id: id(uri()),
+		name: field('vcard$fn', String)
+	})
+	t.throws(() => UnknownIdValue.toOldm({ id: 'unknown$me', name: 'Auke' }, graph), /OLDM shape prefix validation failed/)
+
+	const UnknownUriValue = shape('vcard$Individual', {
+		homepage: field('foaf$homepage', uri())
+	})
+	t.throws(() => UnknownUriValue.toOldm({ homepage: 'unknown$home' }, graph), /OLDM shape prefix validation failed/)
+
+	const WithKnownProjectPrefix = shape('ex$Thing', {
+		id: id(uri()),
+		link: field('ex$link', uri())
+	})
+	const context = oldm({ prefixes: { ex: 'https://example.org/ns#' } })
+	const projectGraph = context.addGraph(new Graph([], 'https://example.org/data.ttl', 'text/turtle', context.prefixes, context))
+	t.doesNotThrow(() => WithKnownProjectPrefix.toOldm({
+		id: 'ex$me',
+		link: 'ex$other'
+	}, projectGraph))
+
+	t.end()
+})
+
+tap.test('toOldm maps objects without ids to blank nodes', t => {
+	const graph = graphFor()
+	const Note = shape({
+		text: field('schema$text', String)
+	})
+	const subject = Note.toOldm({ text: 'Hello' }, graph)
+
+	t.notOk(subject.id)
+	t.equal(subject.schema$text, 'Hello')
+	t.equal(subject.graph, graph)
+
+	t.end()
+})
+
+tap.test('fromOldm maps OLDM subjects back to JavaScript objects', t => {
+	const graph = graphFor()
+	const subject = Contact.toOldm(contact, graph)
+	const result = Contact.fromOldm(subject)
+
+	t.same(result, contact)
+	t.end()
+})
+
+tap.test('fromOldm detects unexpected missing RDF type by default', t => {
+	const graph = graphFor()
+	const subject = Contact.toOldm(contact, graph)
+	delete subject.a
+
+	t.throws(() => Contact.fromOldm(subject), /OLDM shape conversion failed/)
+	t.same(Contact.fromOldm(subject, { requireType: false }), contact)
+	t.end()
+})
+
+tap.test('fromOldm rejects multiple RDF values for scalar JavaScript fields', t => {
+	const graph = graphFor()
+	const subject = Contact.toOldm(contact, graph)
+	subject.vcard$fn = ['Auke', 'Other']
+
+	t.throws(() => Contact.fromOldm(subject), /OLDM shape conversion failed/)
+	t.end()
+})
+
+tap.test('Required preserves mapping metadata when wrapping field definitions', t => {
+	const Person = shape('foaf$Person', {
+		id: Required(id(uri())),
+		name: Required(field('foaf$name', String))
+	})
+	const graph = graphFor()
+	const subject = Person.toOldm({
+		id: 'https://example.org/profile/card#me',
+		name: 'Auke'
+	}, graph)
+
+	t.equal(subject.id, 'https://example.org/profile/card#me')
+	t.equal(subject.foaf$name, 'Auke')
+	t.end()
+})

--- a/packages/oldm-turtle/package.json
+++ b/packages/oldm-turtle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-labs/oldm-turtle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Small Turtle 1.1 parser/writer adapter for OLDM",
   "type": "module",
   "main": "src/oldm-turtle.mjs",
@@ -19,7 +19,7 @@
   "author": "auke@muze.nl",
   "license": "MIT",
   "dependencies": {
-    "@muze-nl/oldm-core": "^0.5.3"
+    "@muze-nl/oldm-core": "^0.6.0"
   },
   "files": [
     "src/",

--- a/packages/oldm/README.md
+++ b/packages/oldm/README.md
@@ -39,6 +39,8 @@ context.graphs                        // [profile, settings]
 context.graph(profileUrl)             // profile
 context.data                          // combined subject list
 context.subjects                      // combined subject map by full URI
+profile.context.data                  // same combined view, starting from a graph
+profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // [profile, settings] when both graphs contain data for that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
@@ -46,6 +48,16 @@ context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
 ```
 
 The combined view merges named subjects by IRI and keeps the original graph views separate. `context.sources(subject, predicate, value)` can be used to inspect which graph contributed a subject, property, or specific property value.
+
+If a loader or middleware gives you a `Graph`, use `graph.context` to access the combined view for all graphs loaded into the same context:
+
+```javascript
+const graph = context.parse(profileTurtle, profileUrl, 'text/turtle')
+
+graph.data             // subjects from this one resource
+graph.context.data     // combined subjects from the whole context
+graph.context.get(id)  // merged subject from the whole context
+```
 
 For source-aware writes, use the graph-specific helpers when you know the resource you want to edit:
 

--- a/packages/oldm/README.md
+++ b/packages/oldm/README.md
@@ -23,6 +23,27 @@ const context = oldm({
 ```
 
 
+## Prefix preference
+
+OLDM shortens predicate and type IRIs with the prefixes configured on the context. Prefix declarations found in Turtle input are parser conveniences; they do not decide the JavaScript property names exposed by OLDM.
+
+When multiple prefixes point at the same namespace, client-provided prefixes are preferred over OLDM defaults, and defaults are preferred over prefixes found in a parsed source document. For example, both `pim:` and `space:` are common aliases for `http://www.w3.org/ns/pim/space#`. Since OLDM prefers `space` for that namespace, profile data using either `pim:storage` or `space:storage` is exposed as `space$storage` in JavaScript.
+
+```javascript
+const context = oldm({
+  parser: n3Parser,
+  prefixes: {
+    space: 'http://www.w3.org/ns/pim/space#'
+  }
+})
+
+const profile = context.parse(turtle, profileUrl, 'text/turtle')
+const me = profile.subjects[`${profileUrl}#me`]
+
+console.log(me.space$storage.id)
+```
+
+
 ## Multiple graphs in one context
 
 A context keeps a registry of every parsed graph. Each `context.parse()` call still returns a `Graph` for the parsed resource, while the context exposes a combined view over all graphs loaded into that context.
@@ -39,8 +60,6 @@ context.graphs                        // [profile, settings]
 context.graph(profileUrl)             // profile
 context.data                          // combined subject list
 context.subjects                      // combined subject map by full URI
-profile.context.data                  // same combined view, starting from a graph
-profile.context.subjects              // same combined subject map, starting from a graph
 context.sources(context.get(`${profileUrl}#me`))
 // [profile, settings] when both graphs contain data for that subject
 context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
@@ -48,16 +67,6 @@ context.sources(context.get(`${profileUrl}#me`), 'vcard$fn')
 ```
 
 The combined view merges named subjects by IRI and keeps the original graph views separate. `context.sources(subject, predicate, value)` can be used to inspect which graph contributed a subject, property, or specific property value.
-
-If a loader or middleware gives you a `Graph`, use `graph.context` to access the combined view for all graphs loaded into the same context:
-
-```javascript
-const graph = context.parse(profileTurtle, profileUrl, 'text/turtle')
-
-graph.data             // subjects from this one resource
-graph.context.data     // combined subjects from the whole context
-graph.context.get(id)  // merged subject from the whole context
-```
 
 For source-aware writes, use the graph-specific helpers when you know the resource you want to edit:
 

--- a/packages/oldm/package.json
+++ b/packages/oldm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muze-nl/oldm",
-  "version": "0.5.3",
+  "version": "0.6.1",
   "description": "Beginner-friendly Object - Linked Data Mapper package",
   "type": "module",
   "main": "src/index.mjs",
@@ -29,8 +29,8 @@
   "author": "auke@muze.nl",
   "license": "MIT",
   "dependencies": {
-    "@muze-nl/oldm-core": "^0.5.3",
-    "@muze-nl/oldm-n3": "^0.5.3"
+    "@muze-nl/oldm-core": "^0.6.0",
+    "@muze-nl/oldm-n3": "^0.6.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
This adds a new package @muze-labs/oldm-shape, which implements a way to convert javascript objects from/to oldm/linked data.

It also fixes a bug in the oldm-core, where default and source defined prefixes where found before client side defined prefixes, so shortUri's became unpredictable.